### PR TITLE
Encode data file SVG/XML special characters to entity references

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -50,6 +50,8 @@ This produces files like:
   * card_1.pdf
   * card_2.pdf
 
+Any special SVG (XML) characters within the CSV data file's values will be automatically converted to XML entity references (such as `&` becoming `&amp;`).
+
 == Contributing to inkscape_merge
  
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet

--- a/lib/inkscape_merge/processor.rb
+++ b/lib/inkscape_merge/processor.rb
@@ -1,3 +1,4 @@
+require 'cgi'
 require 'ostruct'
 require 'tempfile'
 require 'fileutils'
@@ -51,7 +52,7 @@ module Inkscape # :nodoc:
                 s.gsub(pattern){|m|
                   puts $1 if @options.verbose
                   # return corresponding value from current row
-                  row[$1]
+                  CGI.escapeHTML(row[$1])
               }
             }
 


### PR DESCRIPTION
This handles the situation where you have a value with special characters in the value within your CSV data file.  For instance, the value of "John & Sara" would previously just be replaced verbatim, resulting in the `&` being invalid (and thus becoming empty space in the final PDF output).  It instead [needs to be](http://commons.oreilly.com/wiki/index.php/SVG_Essentials/The_XML_You_Need_for_SVG#Entity_References) encoded as `&amp;`.

This PR adds support for encoding all predefined entity references in XML as they get replaced into the outputted document using [`cgi.escapeHTML`](http://ruby-doc.org/stdlib-2.4.0/libdoc/cgi/rdoc/CGI/Util.html#method-i-escapeHTML).